### PR TITLE
Integrates AuthIMAP with AuthPlain (v2)

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -79,8 +79,7 @@ class auth_plugin_authimap extends auth_plugin_authplain {
             imap_close($imap_login);
             return true;
         } else {
-            $localUserInfo = $auth->getUserData($localUser);
-            return parent::checkPass($localUserInfo['user'], $pass);
+            return parent::checkPass($localUser, $pass);
         }
         return false;
     }

--- a/auth.php
+++ b/auth.php
@@ -84,6 +84,11 @@ class auth_plugin_authimap extends auth_plugin_authplain {
         return false;
     }
     
+    /**
+     * Enhance function to sanitize username
+     *
+     * @inheritdoc
+     */
     public function getUserData($user, $requireGroups = false) {
         return parent::getUserData($this->cleanUser($user), $requireGroups);
     }

--- a/auth.php
+++ b/auth.php
@@ -84,6 +84,10 @@ class auth_plugin_authimap extends auth_plugin_authplain {
         return false;
     }
     
+    public function getUserData($user, $requireGroups = false) {
+        return parent::getUserData($this->cleanUser($user), $requireGroups);
+    }
+    
     /**
      * Enhance function to check against duplicate emails
      *

--- a/auth.php
+++ b/auth.php
@@ -85,15 +85,6 @@ class auth_plugin_authimap extends auth_plugin_authplain {
     }
     
     /**
-     * Enhance function to sanitize username
-     *
-     * @inheritdoc
-     */
-    public function getUserData($user, $requireGroups = false) {
-        return parent::getUserData($this->cleanUser($user), $requireGroups);
-    }
-    
-    /**
      * Enhance function to check against duplicate emails
      *
      * @inheritdoc

--- a/auth.php
+++ b/auth.php
@@ -70,8 +70,8 @@ class auth_plugin_authimap extends auth_plugin_authplain {
             $login = $user;
         }
         
-        $userinfo = $this->getUserData($user);
-        if ($userinfo === false) return false;
+        $localUser = $this->getUserByEmail("$user@$domain");
+        if (!$localUser) return false;
 
         // check at imap server
         $imap_login = @imap_open($server, $login, $pass, OP_READONLY);
@@ -79,7 +79,8 @@ class auth_plugin_authimap extends auth_plugin_authplain {
             imap_close($imap_login);
             return true;
         } else {
-            return parent::checkPass($user, $pass);
+            $localUserInfo = $auth->getUserData($localUser);
+            return parent::checkPass($localUserInfo['user'], $pass);
         }
         return false;
     }

--- a/auth.php
+++ b/auth.php
@@ -116,7 +116,7 @@ class auth_plugin_authimap extends auth_plugin_authplain {
             }
         }
 
-        $ok = parent::modifyUser($user, $changes);
+        return parent::modifyUser($user, $changes);
     }
     
     // endregion

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * English language file for oauth plugin
+ * English language file for authimap plugin
  *
  * @author Andreas Gohr <andi@splitbrain.org>
  */

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * English language file for oauth plugin
+ *
+ * @author Andreas Gohr <andi@splitbrain.org>
+ */
+
+$lang['emailduplicate'] = 'This email is already associated with another user.';


### PR DESCRIPTION
Attempts to add local authentication support for AuthIMAP plugin (fixes #1).
--
Hello @splitbrain, thank you for helping me to figure out and developing a better integration of this plug-in with AuthPlain. I'm a sysadmin and I'm simply trying to make it work, and hopes that these changes can improve the functionality of this plugin and help other people.
This commit extends the AuthPlain plug-in and also changes the behavior of this plug-in. As the ``getUserData`` function is now inherited from it's AuthPlain, this commit also changes the plug-in behavior (I couldn't figure out how to return localUser info and the default array from AuthIMAP, and when creating a user it always returning as the user already existed because it was loading the array from AuthIMAP, and in fact it doesn't seem the username needs any kind of sanitize at all because it's created locally by the user - so I removed the ``getUserData`` function from AuthIMAP plugin).
Now if the user do not have a local user at the local user file of DokuWiki, he/she will not be allowed to login, even if the IMAP credentials are valid. An administrator should create a local DokuWiki user for the user to login. In my opinion, this increases the security (as we can control more easily who can access the DokuWiki - having a valid mail credentials at the IMAP server isn't enough) and we can also assign groups to the user instead of falling back to the default one. This commit also allows the user to login locally by using it's local DokuWiki username or mail (if the user knows it's local password) and only attempt this if the IMAP authentication fails. It should allow other features from authplain plugin, like allows the user to reset he/she DokuWiki user local password.
In order for the user to be able to authenticate, their email address must match the email address of a local DokuWiki user.